### PR TITLE
adds monkie cubes to req

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1264,6 +1264,12 @@ SUPPLIES
 		/obj/item/paper/janitor,
 	)
 	cost = 5
+	
+/datum/supply_packs/supplies/monkey
+	name = "monkey cube crate"
+	notes = "Contains a box of 5 monkey cubes"
+	contains = list(/obj/item/storage/box/monkeycubes)
+	cost = 30
 
 /*******************************************************************************
 Imports


### PR DESCRIPTION
<!-- ***STOP!***  Read this: If this is not a PR ready for review and merge or WIP, open it as a draft PR, using the arrow next to 'Create Pull Request'>

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Monkey cubes can now be purchased from requisitions at the cost of 30 points for a box of 5 cubes.
## Why It's Good For The Game
Allows for monkey related shenanigans and feeding xenos. Lets researchers do something during the round.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Matlap
add: Monkey cubes are now available through requisitions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
